### PR TITLE
bump deps

### DIFF
--- a/src/client/package.json
+++ b/src/client/package.json
@@ -6,15 +6,15 @@
   },
   "dependencies": {
     "markdown-it": "^14.1.0",
-    "nanoid": "^5.0.7",
+    "nanoid": "^5.1.5",
     "partysocket": "^1.1.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/react": "^18.3.8",
-    "@types/react-dom": "^18.3.0",
-    "esbuild": "^0.24.0"
+    "@types/react": "^19.0.12",
+    "@types/react-dom": "^19.0.4",
+    "esbuild": "^0.25.1"
   }
 }

--- a/src/dev/package.json
+++ b/src/dev/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "dependencies": {
-    "fast-glob": "^3.3.2",
-    "wrangler": "^3.81.0"
+    "fast-glob": "^3.3.3",
+    "wrangler": "^4.4.0"
   },
   "scripts": {
     "build": "node build-manifest.js",

--- a/src/worker/package.json
+++ b/src/worker/package.json
@@ -8,28 +8,27 @@
     "tail": "wrangler tail",
     "dev-jldec": "wrangler -c wrangler-jldec.toml dev src/index.tsx",
     "ship-jldec": "wrangler -c wrangler-jldec.toml deploy --minify src/index.tsx",
-    "tail-jldec": "wrangler -c wrangler-jldec.toml tail",
-    "test": "vitest"
+    "tail-jldec": "wrangler -c wrangler-jldec.toml tail"
   },
   "dependencies": {
-    "@std/front-matter": "npm:@jsr/std__front-matter@1.0.5",
-    "@std/media-types": "npm:@jsr/std__media-types@^1.0.3",
-    "@std/path": "npm:@jsr/std__path@^1.0.6",
-    "eventsource-parser": "^2.0.1",
-    "hono": "^4.6.3",
+    "@std/front-matter": "npm:@jsr/std__front-matter@1.0.8",
+    "@std/media-types": "npm:@jsr/std__media-types@^1.1.0",
+    "@std/path": "npm:@jsr/std__path@^1.0.8",
+    "eventsource-parser": "^3.0.0",
+    "hono": "^4.7.5",
     "markdown-it": "^14.1.0",
-    "nanoid": "^5.0.7",
+    "nanoid": "^5.1.5",
     "partyserver": "^0.0.66"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20241112.0",
-    "@tailwindcss/typography": "^0.5.15",
+    "@cloudflare/workers-types": "^4.20250321.0",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/markdown-it": "^14.1.2",
-    "autoprefixer": "^10.4.20",
+    "autoprefixer": "^10.4.21",
     "htmx.org": "^2.0.3",
-    "postcss": "^8.4.47",
-    "tailwindcss": "^3.4.14",
-    "vitest": "^2.1.2",
-    "wrangler": "^3.86.1"
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "vitest": "^3.0.9",
+    "wrangler": "^4.4.0"
   }
 }

--- a/src/worker/wrangler-jldec.toml
+++ b/src/worker/wrangler-jldec.toml
@@ -1,5 +1,5 @@
 name = "jldec-worker"
-compatibility_date = "2024-11-06"
+compatibility_date = "2025-03-21"
 assets = { directory = "../../public" }
 main = "src/index.tsx"
 

--- a/src/worker/wrangler.toml
+++ b/src/worker/wrangler.toml
@@ -1,5 +1,5 @@
 name = "presskit-worker"
-compatibility_date = "2024-11-06"
+compatibility_date = "2025-03-21"
 assets = { directory = "../../public" }
 main = "src/index.tsx"
 


### PR DESCRIPTION
bumps wrangler, react etc.

NOTE: does not adopt the new [generated workers types](https://developers.cloudflare.com/workers/languages/typescript/#generate-types). Env types are maintained in `src/worker/src/types.ts` and there are 2 wrangler.toml files with different env vars - I didn't want to rework that config.
